### PR TITLE
[1.0] LiveActivityのリセットボタン押下でタイマーリセットする機能の追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,6 @@ jobs:
           -scmProvider xcode
           -allowProvisioningUpdates
           -skipPackagePluginValidation
+          -parallel-testing-enabled NO
           clean test |
           bundle exec xcpretty

--- a/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
+++ b/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
@@ -59,6 +59,8 @@
 		BC57C0EC2C996B9500786503 /* TimerStartIntentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0EB2C996B9500786503 /* TimerStartIntentTest.swift */; };
 		BC57C0EF2C99C69900786503 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0EE2C99C69900786503 /* TestUtilities.swift */; };
 		BC57C0F12C99CDED00786503 /* TimerStopIntentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F02C99CDED00786503 /* TimerStopIntentTest.swift */; };
+		BC57C0F42C9A7A0200786503 /* WidgetUrlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */; };
+		BC57C0F52C9A801400786503 /* WidgetUrlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */; };
 		BC5D47072C947C8400C52820 /* TimerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD922C91429900F3AC29 /* TimerStatus.swift */; };
 		BC5D47082C947D8200C52820 /* TimerActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD942C9142BF00F3AC29 /* TimerActionType.swift */; };
 		BC5D47092C947E4B00C52820 /* ResourceAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD9E2C914E2900F3AC29 /* ResourceAdapt.swift */; };
@@ -144,6 +146,7 @@
 		BC57C0EB2C996B9500786503 /* TimerStartIntentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStartIntentTest.swift; sourceTree = "<group>"; };
 		BC57C0EE2C99C69900786503 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		BC57C0F02C99CDED00786503 /* TimerStopIntentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStopIntentTest.swift; sourceTree = "<group>"; };
+		BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUrlKey.swift; sourceTree = "<group>"; };
 		BCB5B59D2C9529D700DB3D79 /* TimerClockAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerClockAnimationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -202,6 +205,7 @@
 		BC057EC02C94758F0030C275 /* TimeWatcherWidget */ = {
 			isa = PBXGroup;
 			children = (
+				BC57C0F22C9A524500786503 /* Definition */,
 				BC57C0D12C990DC700786503 /* Intent */,
 				BC057EC12C94758F0030C275 /* TimeWatcherWidgetBundle.swift */,
 				BC057EC32C94758F0030C275 /* TimeWatcherWidgetLiveActivity.swift */,
@@ -421,6 +425,14 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		BC57C0F22C9A524500786503 /* Definition */ = {
+			isa = PBXGroup;
+			children = (
+				BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */,
+			);
+			path = Definition;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -601,6 +613,7 @@
 				BC57C0E92C99480800786503 /* TimeInterval+Extension.swift in Sources */,
 				BC57C0D72C991C0500786503 /* DateDependency.swift in Sources */,
 				BC5D47092C947E4B00C52820 /* ResourceAdapt.swift in Sources */,
+				BC57C0F52C9A801400786503 /* WidgetUrlKey.swift in Sources */,
 				BC04009A2C949BD3003558DB /* FrameButtonStyle.swift in Sources */,
 				BC57C0DD2C991D5700786503 /* TimerControlable.swift in Sources */,
 				BC057EC22C94758F0030C275 /* TimeWatcherWidgetBundle.swift in Sources */,
@@ -631,6 +644,7 @@
 				BC57C0CE2C96A0E300786503 /* LiveActivityManagerMock.swift in Sources */,
 				BC4B66302C955B1B004C3EEF /* LiveActivityManager.swift in Sources */,
 				BC3FCD932C91429900F3AC29 /* TimerStatus.swift in Sources */,
+				BC57C0F42C9A7A0200786503 /* WidgetUrlKey.swift in Sources */,
 				BC3FCD952C9142BF00F3AC29 /* TimerActionType.swift in Sources */,
 				BC3FCDB32C91DF8800F3AC29 /* Logger.swift in Sources */,
 				BC3FCDA32C91527100F3AC29 /* FrameButtonStyle.swift in Sources */,

--- a/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
+++ b/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		BC57C0F12C99CDED00786503 /* TimerStopIntentTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F02C99CDED00786503 /* TimerStopIntentTest.swift */; };
 		BC57C0F42C9A7A0200786503 /* WidgetUrlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */; };
 		BC57C0F52C9A801400786503 /* WidgetUrlKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */; };
+		BC57C0F72C9A8D1700786503 /* OpenUrlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0F62C9A8D1700786503 /* OpenUrlViewModel.swift */; };
+		BC57C0FC2C9A938900786503 /* OpenUrlViewModelTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC57C0FB2C9A938900786503 /* OpenUrlViewModelTest.swift */; };
 		BC5D47072C947C8400C52820 /* TimerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD922C91429900F3AC29 /* TimerStatus.swift */; };
 		BC5D47082C947D8200C52820 /* TimerActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD942C9142BF00F3AC29 /* TimerActionType.swift */; };
 		BC5D47092C947E4B00C52820 /* ResourceAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD9E2C914E2900F3AC29 /* ResourceAdapt.swift */; };
@@ -147,6 +149,8 @@
 		BC57C0EE2C99C69900786503 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
 		BC57C0F02C99CDED00786503 /* TimerStopIntentTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerStopIntentTest.swift; sourceTree = "<group>"; };
 		BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUrlKey.swift; sourceTree = "<group>"; };
+		BC57C0F62C9A8D1700786503 /* OpenUrlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlViewModel.swift; sourceTree = "<group>"; };
+		BC57C0FB2C9A938900786503 /* OpenUrlViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlViewModelTest.swift; sourceTree = "<group>"; };
 		BCB5B59D2C9529D700DB3D79 /* TimerClockAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerClockAnimationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -262,6 +266,7 @@
 		BC3FCD742C913E2B00F3AC29 /* TimeWatcherTests */ = {
 			isa = PBXGroup;
 			children = (
+				BC57C0F82C9A935400786503 /* RootView */,
 				BC57C0ED2C99C68700786503 /* Utilities */,
 				BC57C0EA2C996B6D00786503 /* TimerWatcherWidgetIntent */,
 				BC057EB12C92801B0030C275 /* MainTimerView */,
@@ -330,7 +335,7 @@
 			isa = PBXGroup;
 			children = (
 				BC4B662E2C955A40004C3EEF /* ViewParts */,
-				BC3FCD642C913E2900F3AC29 /* TimeWatcherApp.swift */,
+				BCF25BC12C9AC369002133A4 /* RootView */,
 				BC3FCD8E2C913FCE00F3AC29 /* MainTimerView */,
 			);
 			path = View;
@@ -431,6 +436,23 @@
 				BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */,
 			);
 			path = Definition;
+			sourceTree = "<group>";
+		};
+		BC57C0F82C9A935400786503 /* RootView */ = {
+			isa = PBXGroup;
+			children = (
+				BC57C0FB2C9A938900786503 /* OpenUrlViewModelTest.swift */,
+			);
+			path = RootView;
+			sourceTree = "<group>";
+		};
+		BCF25BC12C9AC369002133A4 /* RootView */ = {
+			isa = PBXGroup;
+			children = (
+				BC3FCD642C913E2900F3AC29 /* TimeWatcherApp.swift */,
+				BC57C0F62C9A8D1700786503 /* OpenUrlViewModel.swift */,
+			);
+			path = RootView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -639,6 +661,7 @@
 				BC4B66332C959A72004C3EEF /* TimeInterval+Extension.swift in Sources */,
 				BC3FCD672C913E2900F3AC29 /* MainTimerView.swift in Sources */,
 				BC3FCDAC2C918A4300F3AC29 /* TimeWatch.swift in Sources */,
+				BC57C0F72C9A8D1700786503 /* OpenUrlViewModel.swift in Sources */,
 				BC57C0E32C99349600786503 /* TimerControlable.swift in Sources */,
 				BC4B66352C95AF0F004C3EEF /* Calendar+Extension.swift in Sources */,
 				BC57C0CE2C96A0E300786503 /* LiveActivityManagerMock.swift in Sources */,
@@ -665,6 +688,7 @@
 				BC57C0EF2C99C69900786503 /* TestUtilities.swift in Sources */,
 				BC57C0EC2C996B9500786503 /* TimerStartIntentTest.swift in Sources */,
 				BC57C0F12C99CDED00786503 /* TimerStopIntentTest.swift in Sources */,
+				BC57C0FC2C9A938900786503 /* OpenUrlViewModelTest.swift in Sources */,
 				BC057EB32C9280470030C275 /* MainTimerViewTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TimeWatcherPrj/TimeWatcher/Utility/Constant/AppConstants.swift
+++ b/TimeWatcherPrj/TimeWatcher/Utility/Constant/AppConstants.swift
@@ -11,7 +11,7 @@ struct AppConstants {
     
     // MARK: - アプリ共通
     
-    static let bundleId = Bundle.main.bundleIdentifier ?? "taichi.sato.dummy"
+    static let mainBundleId = "taichi.satou.TimeWatcher"
     
     // MARK: - ウォッチ関連のプロパティ
     

--- a/TimeWatcherPrj/TimeWatcher/Utility/Constant/AppConstants.swift
+++ b/TimeWatcherPrj/TimeWatcher/Utility/Constant/AppConstants.swift
@@ -9,6 +9,12 @@ import Foundation
 
 struct AppConstants {
     
+    // MARK: - アプリ共通
+    
+    static let bundleId = Bundle.main.bundleIdentifier ?? "taichi.sato.dummy"
+    
+    // MARK: - ウォッチ関連のプロパティ
+    
     // 最大表示時間
     static let maxDisplayTimeString = "99:59:59.999"
     // 最大表示時間

--- a/TimeWatcherPrj/TimeWatcher/View/MainTimerView/MainTimerView.swift
+++ b/TimeWatcherPrj/TimeWatcher/View/MainTimerView/MainTimerView.swift
@@ -11,6 +11,7 @@ import TimeWatcherExternalResouce
 struct MainTimerView: View {
     
     @StateObject var viewModel: MainTimerViewModel
+    @EnvironmentObject var openUrlViewModel: OpenUrlViewModel
     
     // MARK: - layout property
     
@@ -48,6 +49,9 @@ struct MainTimerView: View {
         }
         .onAppear {
             viewModel.onAppear()
+        }
+        .onReceive(openUrlViewModel.$widgetUrlKey.compactMap { $0 }) { widgetUrl in
+            viewModel.onOpenLiveActivityUrl(widgetUrl)
         }
     }
 }
@@ -100,8 +104,10 @@ private extension MainTimerView {
 
 #Preview("通常時") {
     MainTimerView(viewModel: MainTimerViewModel())
+        .environmentObject(OpenUrlViewModel())
 }
 
 #Preview("最大表示可能経過時間超過時") {
     MainTimerView(viewModel: MainTimerViewModel(isOverMaxTime: true))
+        .environmentObject(OpenUrlViewModel())
 }

--- a/TimeWatcherPrj/TimeWatcher/View/MainTimerView/MainTimerViewModel.swift
+++ b/TimeWatcherPrj/TimeWatcher/View/MainTimerView/MainTimerViewModel.swift
@@ -73,6 +73,8 @@ class MainTimerViewModel: ObservableObject {
     /// 画面表示時の処理
     func onAppear() {
         
+        logger.info("[In]")
+        
         // TimerStatusの監視
         addObserveTimerStatus()
     }
@@ -86,14 +88,27 @@ class MainTimerViewModel: ObservableObject {
         switch type {
             
         case .start:
-            tappedStartTimerButton()
+            startTimer()
             
         case .stop:
-            tappedStopTimerButton()
+            stopTimer()
             
         case .reset:
-            tappedResetTimerButton()
+            resetTimer()
         }
+    }
+    
+    /// LiveActivityのDeepLinkでアプリが開かれたことを検知
+    /// - Parameter url: LiveActivityから開かれるURLのKey
+    func onOpenLiveActivityUrl(_ url: WidgetUrlKey) {
+        
+        logger.info("url: \(url)")
+        
+        // リセット以外のリンクの場合は、特に実行する処理はないため無視する
+        if url != .timerResetLink { return }
+        
+        // タイマーをリセットする
+        resetTimer()
     }
 }
 
@@ -103,6 +118,8 @@ class MainTimerViewModel: ObservableObject {
 private extension MainTimerViewModel {
     
     func addObserveTimerStatus() {
+        
+        logger.info("[In]")
         
         timerStatusObserveCancellable = timeWatch.createTimerStatusPublisher()
             .receive(on: DispatchQueue.main)
@@ -115,8 +132,10 @@ private extension MainTimerViewModel {
             }
     }
     
-    /// タイマー開始ボタン押下
-    func tappedStartTimerButton() {
+    /// タイマー開始
+    func startTimer() {
+        
+        logger.info("[In]")
         
         timeWatch.startTimer()
         
@@ -141,8 +160,10 @@ private extension MainTimerViewModel {
         }
     }
     
-    /// タイマー停止ボタン押下
-    func tappedStopTimerButton() {
+    /// タイマー停止
+    func stopTimer() {
+        
+        logger.info("[In]")
         
         // 現在リクエストしているTaskをすべてキャンセルする
         cancelLiveActivityTask()
@@ -165,8 +186,10 @@ private extension MainTimerViewModel {
         }
     }
     
-    /// タイマーリセットボタン押下
-    func tappedResetTimerButton() {
+    /// タイマーリセット
+    func resetTimer() {
+        
+        logger.info("[In]")
         
         // 現在リクエストしているTaskをすべてキャンセルする
         cancelLiveActivityTask()

--- a/TimeWatcherPrj/TimeWatcher/View/RootView/OpenUrlViewModel.swift
+++ b/TimeWatcherPrj/TimeWatcher/View/RootView/OpenUrlViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  OpenUrlViewModel.swift
+//  TimeWatcher
+//
+//  Created by 佐藤汰一 on 2024/09/18.
+//
+
+import Foundation
+
+@MainActor
+class OpenUrlViewModel: ObservableObject {
+    
+    /// LiveActivityから開かれた際のURL
+    @Published var widgetUrlKey: WidgetUrlKey?
+    
+    /// 開かれたURLの設定
+    func setUrl(_ url: URL) {
+                
+        guard let widgetURL = WidgetUrlKey.allCases.first(where: { $0.url == url }) else {
+            
+            logger.debug("Not found widget url: \(url).")
+            return
+        }
+        
+        logger.info("Did open widget url: \(widgetURL).")
+        widgetUrlKey = widgetURL
+    }
+}

--- a/TimeWatcherPrj/TimeWatcher/View/RootView/TimeWatcherApp.swift
+++ b/TimeWatcherPrj/TimeWatcher/View/RootView/TimeWatcherApp.swift
@@ -8,13 +8,19 @@
 import SwiftUI
 
 @main
+@MainActor
 struct TimeWatcherApp: App {
+    
+    // Deep Linkで開かれた際の情報を持つViewModel
+    private var openUrlViewModel = OpenUrlViewModel()
     
     var body: some Scene {
         WindowGroup {
             MainTimerView(viewModel: MainTimerViewModel())
+                .environmentObject(openUrlViewModel)
                 .onOpenURL { url in
                     logger.info("URL: \(url)")
+                    openUrlViewModel.setUrl(url)
                 }
         }
     }

--- a/TimeWatcherPrj/TimeWatcher/View/TimeWatcherApp.swift
+++ b/TimeWatcherPrj/TimeWatcher/View/TimeWatcherApp.swift
@@ -9,9 +9,13 @@ import SwiftUI
 
 @main
 struct TimeWatcherApp: App {
+    
     var body: some Scene {
         WindowGroup {
             MainTimerView(viewModel: MainTimerViewModel())
+                .onOpenURL { url in
+                    logger.info("URL: \(url)")
+                }
         }
     }
 }

--- a/TimeWatcherPrj/TimeWatcherTests/MainTimerView/MainTimerViewTest.swift
+++ b/TimeWatcherPrj/TimeWatcherTests/MainTimerView/MainTimerViewTest.swift
@@ -48,7 +48,12 @@ final class MainTimerViewTest: XCTestCase {
         let testTimeWatch = TimeWatch(publisher: testTimerPublisher.eraseToAnyPublisher(),
                                       currentTime: dependencyDate)
         
-        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch)
+        let liveActivityManager = LiveActivityManagerMock(startProc: { _ in },
+                                                          updateProc: { _ in },
+                                                          stopProc: {})
+        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch,
+                                               liveActivityMgr: liveActivityManager,
+                                               dateDependency: dependencyDate)
         
         // 画面表示
         testViewModel.onAppear()
@@ -94,7 +99,12 @@ final class MainTimerViewTest: XCTestCase {
         
         let testTimeWatch = TimeWatch(publisher: testTimerPublisher.eraseToAnyPublisher(),
                                       currentTime: dependencyDate)
-        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch)
+        let liveActivityManager = LiveActivityManagerMock(startProc: { _ in },
+                                                          updateProc: { _ in },
+                                                          stopProc: {})
+        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch,
+                                               liveActivityMgr: liveActivityManager,
+                                               dateDependency: dependencyDate)
         
         // 画面表示
         testViewModel.onAppear()
@@ -168,7 +178,12 @@ final class MainTimerViewTest: XCTestCase {
         
         let testTimeWatch = TimeWatch(publisher: testTimerPublisher.eraseToAnyPublisher(),
                                       currentTime: dependencyDate)
-        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch)
+        let liveActivityManager = LiveActivityManagerMock(startProc: { _ in },
+                                                          updateProc: { _ in },
+                                                          stopProc: {})
+        let testViewModel = MainTimerViewModel(timeWatch: testTimeWatch,
+                                               liveActivityMgr: liveActivityManager,
+                                               dateDependency: dependencyDate)
         
         // 画面表示
         testViewModel.onAppear()

--- a/TimeWatcherPrj/TimeWatcherTests/RootView/OpenUrlViewModelTest.swift
+++ b/TimeWatcherPrj/TimeWatcherTests/RootView/OpenUrlViewModelTest.swift
@@ -1,0 +1,87 @@
+//
+//  OpenUrlViewModelTest.swift
+//  TimeWatcherTests
+//
+//  Created by 佐藤汰一 on 2024/09/18.
+//
+
+import XCTest
+@testable import TimeWatcher
+
+final class OpenUrlViewModelTest: XCTestCase {
+
+    /// WidgetUrlでアプリが開かれた時のケース
+    ///
+    /// # 確認ポイント
+    /// - WidgetURLをViewModelで設定したときに、WidgetURLのプロパティが想定通り更新されること
+    @MainActor
+    func testWidgetUrlOpen() throws {
+        
+        let testViewModel = OpenUrlViewModel()
+        
+        for widgetUrl in WidgetUrlKey.allCases {
+            
+            // リセットのURLでオープン
+            testViewModel.setUrl(widgetUrl.url)
+            
+            // URL確認
+            checkWidgetUrl(testViewModel, expected: widgetUrl)
+        }
+    }
+    
+    /// 想定外のURLでアプリが開かれた時のケース
+    ///
+    /// # 確認ポイント
+    /// - 想定外のURLをViewModelで設定したときに、WidgetURLのプロパティが想定通り更新されないこと
+    @MainActor
+    func testOtherUrlOpen() throws {
+        
+        let testViewModel = OpenUrlViewModel()
+        
+        // リセットのURLでオープン
+        testViewModel.setUrl(URL(string: "https://demmy.com")!)
+        
+        // WidgetURLが更新されないことを確認
+        checkNoUpdateWidgetUrl(testViewModel)
+    }
+}
+
+@MainActor
+private extension OpenUrlViewModelTest {
+    
+    func checkWidgetUrl(_ viewModel: OpenUrlViewModel, expected: WidgetUrlKey?) {
+        
+        let expectation = XCTestExpectation(description: "testWidgetUrlOpen")
+        expectation.expectedFulfillmentCount = 1
+        
+        let widgetUrlCancellable = viewModel.$widgetUrlKey.sink { urlKey in
+            
+            if urlKey == expected {
+                
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1)
+        
+        widgetUrlCancellable.cancel()
+    }
+    
+    func checkNoUpdateWidgetUrl(_ viewModel: OpenUrlViewModel) {
+        
+        let expectation = XCTestExpectation(description: "checkNoUpdateWidgetUrl")
+        expectation.isInverted = true
+        
+        let widgetUrlCancellable = viewModel.$widgetUrlKey.sink { urlKey in
+            
+            if urlKey != nil {
+                
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1)
+        
+        widgetUrlCancellable.cancel()
+    }
+}

--- a/TimeWatcherPrj/TimeWatcherWidget/Definition/WidgetUrlKey.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/Definition/WidgetUrlKey.swift
@@ -22,13 +22,13 @@ extension WidgetUrlKey {
     
     private static var defaultURL: URL {
         
-        return URL(string: "\(scheme)\(AppConstants.bundleId)")!
+        return URL(string: "\(scheme)\(AppConstants.mainBundleId)")!
     }
     
     /// Keyに紐づくWidgetURL
     var url: URL {
         
-        return URL(string: "\(Self.scheme)\(AppConstants.bundleId)\(self.path)") ?? Self.defaultURL
+        return URL(string: "\(Self.scheme)\(AppConstants.mainBundleId)\(self.path)") ?? Self.defaultURL
     }
     
     var path: String {

--- a/TimeWatcherPrj/TimeWatcherWidget/Definition/WidgetUrlKey.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/Definition/WidgetUrlKey.swift
@@ -1,0 +1,45 @@
+//
+//  WidgetUrlKey.swift
+//  TimeWatcher
+//
+//  Created by 佐藤汰一 on 2024/09/18.
+//
+
+import Foundation
+
+/// WidgetURLで使用するURLのKey
+enum WidgetUrlKey: CaseIterable {
+    
+    /// タイマーリセットのリンク
+    case timerResetLink
+    /// その他デフォルトのリンク
+    case defaultLink
+}
+
+extension WidgetUrlKey {
+    
+    private static let scheme = "https://"
+    
+    private static var defaultURL: URL {
+        
+        return URL(string: "\(scheme)\(AppConstants.bundleId)")!
+    }
+    
+    /// Keyに紐づくWidgetURL
+    var url: URL {
+        
+        return URL(string: "\(Self.scheme)\(AppConstants.bundleId)\(self.path)") ?? Self.defaultURL
+    }
+    
+    var path: String {
+        
+        switch self {
+            
+        case .timerResetLink:
+            return "/reset"
+            
+        case .defaultLink:
+            return ""
+        }
+    }
+}

--- a/TimeWatcherPrj/TimeWatcherWidget/TimeWatcherWidgetLiveActivity.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/TimeWatcherWidgetLiveActivity.swift
@@ -80,7 +80,7 @@ struct TimeWatcherWidgetLiveActivity: Widget {
     private let actionButtonIconSize: CGFloat = 40
     private let shortTimeClockLineWidth: CGFloat = 2
     private let compactTextWidth: CGFloat = 65
-    private let expandedTextWidth: CGFloat = 100
+    private let expandedTextWidth: CGFloat = 110
     private let contentTimerTextWidth: CGFloat = 120
     
     // MARK: live activity view body property
@@ -242,7 +242,7 @@ extension TimeWatcherWidgetAttributes {
 extension TimeWatcherWidgetAttributes.ContentState {
     
     fileprivate static var initial: TimeWatcherWidgetAttributes.ContentState {
-        return TimeWatcherWidgetAttributes.ContentState(timeLapse: Calendar.current.date(byAdding: .hour, value: -12, to: Date.now)!...Calendar.current.date(byAdding: .hour, value: 100, to: Date.now)!,
+        return TimeWatcherWidgetAttributes.ContentState(timeLapse: Calendar.current.date(byAdding: .hour, value: -99, to: Date.now)!...Calendar.current.date(byAdding: .hour, value: 100, to: Date.now)!,
                                                         timeLapseString: "01:12:12",
                                                         timerStatus: .initial)
     }

--- a/TimeWatcherPrj/TimeWatcherWidget/TimeWatcherWidgetLiveActivity.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/TimeWatcherWidgetLiveActivity.swift
@@ -101,6 +101,7 @@ struct TimeWatcherWidgetLiveActivity: Widget {
             .padding(.horizontal, liveActivityHorizontalPadding)
             .activityBackgroundTint(Color(CustomColor.primaryBackgroundColor))
             .activitySystemActionForegroundColor(Color(CustomColor.primaryForegroundColor))
+            .widgetURL(WidgetUrlKey.defaultLink.url)
         } dynamicIsland: { context in
             DynamicIsland { // MARK: Expanded View
                 DynamicIslandExpandedRegion(.leading) {
@@ -129,6 +130,7 @@ struct TimeWatcherWidgetLiveActivity: Widget {
             } minimal: { // MARK: Minimal View
                 createMiniStatusIconView(context.state.statusIcon)
             }
+            .widgetURL(WidgetUrlKey.defaultLink.url)
         }
     }
 }
@@ -141,15 +143,30 @@ private extension TimeWatcherWidgetLiveActivity {
     func createActionButtonView(useableActions: [TimerActionType], token: String) -> some View {
         HStack(spacing: actionButtonSpacing) {
             ForEach(useableActions, id: \.self) { type in
-                Button(intent: type.getIntent(token: token)) {
-                    Image(systemName: type.buttonIconName)
-                        .resizable()
-                        .padding(actionButtonIconPadding)
-                        .frame(width: actionButtonIconSize,
-                               height: actionButtonIconSize)
-                        .accessibilityHidden(true)
+                if type == .reset {
+                    Link(destination: WidgetUrlKey.timerResetLink.url) {
+                        Image(systemName: type.buttonIconName)
+                            .resizable()
+                            .padding(actionButtonIconPadding)
+                            .frame(width: actionButtonIconSize,
+                                   height: actionButtonIconSize)
+                            .accessibilityHidden(true)
+                            .foregroundStyle(Color(CustomColor.timerActionForegroundColor))
+                            .background(Color(CustomColor.timerActionBackgroundColor))
+                            .clipShape(Circle())
+                    }
                 }
-                .frameButtonStyle(radius: actionButtonIconSize / 2)
+                else {
+                    Button(intent: type.getIntent()) {
+                        Image(systemName: type.buttonIconName)
+                            .resizable()
+                            .padding(actionButtonIconPadding)
+                            .frame(width: actionButtonIconSize,
+                                   height: actionButtonIconSize)
+                            .accessibilityHidden(true)
+                    }
+                    .frameButtonStyle(radius: actionButtonIconSize / 2)
+                }
             }
         }
     }
@@ -190,9 +207,9 @@ private extension TimeWatcherWidgetLiveActivity {
 fileprivate extension TimerActionType {
     
     @MainActor
-    func getIntent(token: String) -> any AppIntent {
+    func getIntent() -> any AppIntent {
         
-        return switch self {
+        let result: (any AppIntent)? = switch self {
             
         case .start:
             TimerStartIntent()
@@ -200,9 +217,16 @@ fileprivate extension TimerActionType {
         case .stop:
             TimerStopIntent()
             
-        case .reset:
-            TimerResetIntent()
+        case .reset: nil
         }
+        
+        guard let result else {
+            
+            assertionFailure("Invalid type: \(self)")
+            return TimerStopIntent()
+        }
+        
+        return result
     }
 }
 


### PR DESCRIPTION
# 概要
LiveActivityのリセットボタン押下でタイマーリセットできるようにする

# 仕様
- LiviActivityをタップするとタップした箇所によって、アプリを開くときの動作が変わる
  - ×ボタン(リセットボタン)をタップすると、起動中のタイマーをリセットし、LiveActivityを終了する
  - それ以外は、アプリを開いた後何もしない

# 動作確認
- [x] UTが全て通ること
- [x] シミュレーターで上記仕様が満たしていること