### PR TITLE
[1.0] プライバシーマニュフェスト対応

### DIFF
--- a/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
+++ b/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
@@ -734,9 +734,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 56LYVN6DMF;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 56LYVN6DMF;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TimeWatcherWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TimeWatcherWidget;
@@ -751,6 +753,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.TimeWatcher.TimeWatcherWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = TimeWatcher_Widget_Dev;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -767,9 +771,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 56LYVN6DMF;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 56LYVN6DMF;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TimeWatcherWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = TimeWatcherWidget;
@@ -784,6 +790,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.TimeWatcher.TimeWatcherWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = TimeWatcher_Widget_Distribution;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -920,10 +928,12 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TimeWatcher/Preview Content\"";
-				DEVELOPMENT_TEAM = 56LYVN6DMF;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 56LYVN6DMF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
@@ -940,6 +950,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.TimeWatcher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = TimeWatcher_Dev;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -952,10 +964,12 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TimeWatcher/Preview Content\"";
-				DEVELOPMENT_TEAM = 56LYVN6DMF;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 56LYVN6DMF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
@@ -972,6 +986,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.TimeWatcher;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = TimeWatcher_Distribution;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
+++ b/TimeWatcherPrj/TimeWatcher.xcodeproj/project.pbxproj
@@ -66,6 +66,8 @@
 		BC5D47072C947C8400C52820 /* TimerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD922C91429900F3AC29 /* TimerStatus.swift */; };
 		BC5D47082C947D8200C52820 /* TimerActionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD942C9142BF00F3AC29 /* TimerActionType.swift */; };
 		BC5D47092C947E4B00C52820 /* ResourceAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3FCD9E2C914E2900F3AC29 /* ResourceAdapt.swift */; };
+		BC6E15B72C9AF80000D518AF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BC6E15B62C9AF80000D518AF /* PrivacyInfo.xcprivacy */; };
+		BC6E15B82C9AF80000D518AF /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BC6E15B62C9AF80000D518AF /* PrivacyInfo.xcprivacy */; };
 		BCB5B59E2C9529D700DB3D79 /* TimerClockAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB5B59D2C9529D700DB3D79 /* TimerClockAnimationView.swift */; };
 		BCB5B59F2C952A7200DB3D79 /* TimerClockAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB5B59D2C9529D700DB3D79 /* TimerClockAnimationView.swift */; };
 /* End PBXBuildFile section */
@@ -151,6 +153,7 @@
 		BC57C0F32C9A7A0200786503 /* WidgetUrlKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUrlKey.swift; sourceTree = "<group>"; };
 		BC57C0F62C9A8D1700786503 /* OpenUrlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlViewModel.swift; sourceTree = "<group>"; };
 		BC57C0FB2C9A938900786503 /* OpenUrlViewModelTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenUrlViewModelTest.swift; sourceTree = "<group>"; };
+		BC6E15B62C9AF80000D518AF /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		BCB5B59D2C9529D700DB3D79 /* TimerClockAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerClockAnimationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -251,6 +254,7 @@
 				BC3FCDAA2C9189CE00F3AC29 /* AppModel */,
 				BC3FCD6A2C913E2B00F3AC29 /* Preview Content */,
 				BC3FCDA02C91507900F3AC29 /* Asset.xcassets */,
+				BC6E15B62C9AF80000D518AF /* PrivacyInfo.xcprivacy */,
 			);
 			path = TimeWatcher;
 			sourceTree = "<group>";
@@ -591,6 +595,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC6E15B82C9AF80000D518AF /* PrivacyInfo.xcprivacy in Resources */,
 				BC057EC82C9475930030C275 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -599,6 +604,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC6E15B72C9AF80000D518AF /* PrivacyInfo.xcprivacy in Resources */,
 				BC3FCDA12C91507900F3AC29 /* Asset.xcassets in Resources */,
 				BC3FCD6C2C913E2B00F3AC29 /* Preview Assets.xcassets in Resources */,
 			);

--- a/TimeWatcherPrj/TimeWatcher/PrivacyInfo.xcprivacy
+++ b/TimeWatcherPrj/TimeWatcher/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+		</dict>
+	</array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/TimeWatcherPrj/TimeWatcher/PrivacyInfo.xcprivacy
+++ b/TimeWatcherPrj/TimeWatcher/PrivacyInfo.xcprivacy
@@ -9,6 +9,12 @@
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+			<key>NSPrivacyCollectedDataType</key>
+			<string></string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<false/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>

--- a/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerResetIntent.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerResetIntent.swift
@@ -15,6 +15,7 @@ struct TimerResetIntent: AppIntent {
     private(set) var timeWatch: TimeWatch
     private let liveActivityManager: LiveActivityManaging
     
+    @preconcurrency
     @MainActor
     init() {
         

--- a/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerStartIntent.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerStartIntent.swift
@@ -15,6 +15,7 @@ struct TimerStartIntent: AppIntent, TimerControlable {
     private(set) var timeWatch: TimeWatch
     private(set) var dateDependency: DateDependency
     
+    @preconcurrency
     @MainActor
     init() {
         

--- a/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerStopIntent.swift
+++ b/TimeWatcherPrj/TimeWatcherWidget/Intent/TimerStopIntent.swift
@@ -15,6 +15,7 @@ struct TimerStopIntent: AppIntent, TimerControlable {
     private(set) var liveActivityManager: LiveActivityManaging
     private(set) var dateDependency: DateDependency
     
+    @preconcurrency
     @MainActor
     init() {
         


### PR DESCRIPTION
# 概要
PrivacyManifestの対応を行う

# PrivacyManifestの内容
- Privacy Tracking Enabled
  - 本アプリではATTを使用しないため"NO"で設定
- Privacy Tracking Domains
  - 本アプリでは外部ネットワークに接続することはないため"NO"で設定
- Privacy Nutrition Label Types
  - Collected Data Type；収集するデータはないので空で設定
  - Linked to User：収集するデータはないので"NO"で設定
  - Used for Tracking：収集するデータはないので"NO"で設定
  - Collection Purposes：収集するデータはないので空で設定
- Privacy Accessed API Types
  - 本アプリでは[該当するAPI](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)を使用していないため未設定

# 動作確認
- [x] UTが全て通ること
- [x] ローカルビルドが通ること