### PR TITLE
fix: CI runner を macos-13 から macos-14 に更新

### DIFF
--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # チェックアウト(リポジトリからソースコードを取得)
       - name: Check Out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Xcodeの一覧出力
       - name: Show Xcode list
@@ -31,7 +31,7 @@ jobs:
 
       # Rudy製ライブラリのキャッシュ
       - name: Cache Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -46,7 +46,7 @@ jobs:
 
       # SPMのライブラリのキャッシュ
       - name: Cache Swift Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}

--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # チェックアウト(リポジトリからソースコードを取得)
       - name: Check Out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Xcodeの一覧出力
       - name: Show Xcode list
@@ -31,7 +31,7 @@ jobs:
 
       # Rudy製ライブラリのキャッシュ
       - name: Cache Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -46,7 +46,7 @@ jobs:
 
       # SPMのライブラリのキャッシュ
       - name: Cache Swift Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.app
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app
   WORKSPACE_PATH: TimerWatcherWorkspace.xcworkspace
   TARGET_SCHEME_NAME: TimeWatcher
   TARGET_TEST_PLAN_NAME: TimeWatcher
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)
@@ -60,7 +60,7 @@ jobs:
           -testPlan ${TARGET_TEST_PLAN_NAME}
           -sdk iphonesimulator
           -configuration Debug
-          -destination "platform=iOS Simulator,OS=17.2,name=iPhone 15 Pro"
+          -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16 Pro"
           -clonedSourcePackagesDirPath SourcePackages
           -scmProvider xcode
           -allowProvisioningUpdates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       # チェックアウト(リポジトリからソースコードを取得)
       - name: Check Out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Xcodeの一覧出力
       - name: Show Xcode list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Rudy製ライブラリのキャッシュ
       - name: Cache Gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -46,7 +46,7 @@ jobs:
 
       # SPMのライブラリのキャッシュ
       - name: Cache Swift Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}


### PR DESCRIPTION
- runs-on: macos-13 -> macos-14 (macos-13 が非サポートになったため)
- Xcode 15.0 -> Xcode 16.2 に更新
- iOS Simulator OS=17.2/iPhone 15 Pro -> OS=18.2/iPhone 16 Pro に更新

https://claude.ai/code/session_01BX2JR5iZMesh2K2M3UyjqV