### PR TITLE
GitHub Actions の runner を macos-14 から macos-15 に変更

### DIFF
--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.2.app
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app
 
 jobs:
   build:

--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.app
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app
 
 jobs:
   build:

--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -6,7 +6,7 @@ on:
       - "release/store/*"
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.app
+  DEVELOPER_DIR: /Applications/Xcode_16.2.app
 
 jobs:
   build:

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -6,7 +6,7 @@ on:
       - "release/store/*"
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.2.app
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_16.2.app
+  DEVELOPER_DIR: /Applications/Xcode_16.4.app
   WORKSPACE_PATH: TimerWatcherWorkspace.xcworkspace
   TARGET_SCHEME_NAME: TimeWatcher
   TARGET_TEST_PLAN_NAME: TimeWatcher
@@ -69,7 +69,7 @@ jobs:
           -testPlan ${TARGET_TEST_PLAN_NAME}
           -sdk iphonesimulator
           -configuration Debug
-          -destination "platform=iOS Simulator,name=iPhone 16 Pro"
+          -destination "platform=iOS Simulator,OS=18.5,name=iPhone 16 Pro"
           -clonedSourcePackagesDirPath SourcePackages
           -scmProvider xcode
           -allowProvisioningUpdates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       # チェックアウト(リポジトリからソースコードを取得)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           -testPlan ${TARGET_TEST_PLAN_NAME}
           -sdk iphonesimulator
           -configuration Debug
-          -destination "platform=iOS Simulator,OS=18.2,name=iPhone 16 Pro"
+          -destination "platform=iOS Simulator,name=iPhone 16 Pro"
           -clonedSourcePackagesDirPath SourcePackages
           -scmProvider xcode
           -allowProvisioningUpdates


### PR DESCRIPTION
macos-14 の runner image 更新により Xcode 16.2 が利用不可となったため、
macos-15 に切り替える。macos-15 では Xcode 16.2 および 16.0 が利用可能。

https://claude.ai/code/session_01WumRyvpcbSotBpVLWbKU8w