### PR TITLE
fix: CDワークフローのSPMキャッシュキーのパスを修正

### DIFF
--- a/.github/workflows/cdBeta.yml
+++ b/.github/workflows/cdBeta.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('TimerWatcherWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
       # GoogleService-Info.plistの復元

--- a/.github/workflows/cdRelease.yml
+++ b/.github/workflows/cdRelease.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('TimerWatcherWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
       # GoogleService-Info.plistの復元

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('TimerWatcherWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
 
       # GoogleService-Info.plistの復元


### PR DESCRIPTION
## 変更の概要

CD ワークフロー（Beta・Release）の Swift Package Manager キャッシュキーに誤ったパスが設定されていた問題を修正します。

## 変更の理由/背景

`xcodebuild -showBuildSettings` がタイムアウトして CD ワークフローが失敗していました。
原因を調査したところ、SPM キャッシュの `hashFiles()` パスに以下の2つの問題があり、キャッシュが**常にミスし続けていた**ことが判明しました。

- `hashFiles()` のパスの途中に**スペースが混入**しており、ファイルが見つからず空のハッシュ値になっていた
- パターンが `*.xcodeproj/project.xcworkspace/...` になっており、本プロジェクトのワークスペース（`TimerWatcherWorkspace.xcworkspace`）を参照できていなかった

毎回 SPM パッケージをネットワーク経由で解決しようとした結果、`xcodebuild -showBuildSettings` がハングしてタイムアウトが発生していました。

## 主な変更点

- `.github/workflows/cdBeta.yml`
  - SPM キャッシュキーの `hashFiles()` パスを修正
  - `'*.xcodeproj/project.xcworkspace/ xcshareddata/swiftpm/Package.resolved'`（空白あり・誤パターン）
  - → `'TimerWatcherWorkspace.xcworkspace/xcshareddata/swiftpm/Package.resolved'`

- `.github/workflows/cdRelease.yml`
  - 同上の修正を適用

## テスト方法

- `release/beta/*` ブランチへの push または `workflow_dispatch` で CD_Beta ワークフローを実行し、`scan` ステップがタイムアウトせず正常完了することを確認

## 関連Issue

- ワークフロー失敗: https://github.com/stotic-dev/TimeWatcher/actions/runs/23324443615/job/67842567693

🤖 Generated with [Claude Code](https://claude.com/claude-code)